### PR TITLE
Use PDT offset

### DIFF
--- a/app/components/conference-session.js
+++ b/app/components/conference-session.js
@@ -1,9 +1,8 @@
 import Component from '@ember/component';
 import RecognizerMixin from 'ember-gestures/mixins/recognizers';
 import { computed } from '@ember/object';
+import ENV from 'emberconf/config/environment';
 import moment from 'moment';
-
-const UTC_OFFSET = '-07:00';
 
 export default Component.extend(RecognizerMixin, {
   recognizers: 'tap',
@@ -35,7 +34,7 @@ export default Component.extend(RecognizerMixin, {
   }),
 
   _pdxMoment(timestamp) {
-    return moment(timestamp).utcOffset(UTC_OFFSET);
+    return moment(timestamp).utcOffset(ENV.APP.UTC_OFFSET);
   },
 
   tap() {

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -2,6 +2,7 @@ import Controller from '@ember/controller';
 import { alias } from '@ember/object/computed';
 import { later } from '@ember/runloop';
 import { inject as service } from '@ember/service';
+import ENV from 'emberconf/config/environment';
 import moment from 'moment';
 
 export default Controller.extend({
@@ -12,9 +13,9 @@ export default Controller.extend({
   now: null,
 
   _setNow() {
-    // FIXME: Force Day 1 date with local clock time for testing
-    let localTime = moment().format('HH:mm:ss');
-    this.set('now', moment(`2018-03-13T${localTime}-07:00`).format());
+    // FIXME: Force Day 1 date with Portland clock time for testing
+    let localTime = moment().utcOffset(ENV.APP.UTC_OFFSET).format('HH:mm:ss');
+    this.set('now', moment(`2018-03-13T${localTime}${ENV.APP.UTC_OFFSET}`).format());
 
     if (this.get('fastboot.isFastBoot')) { return; }
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -20,6 +20,7 @@ module.exports = function(environment) {
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
+      UTC_OFFSET: '-07:00'
     }
   };
 


### PR DESCRIPTION
This is a partial step toward #3 which forces the PDT offset rather than using the local device time. We will still need to update the following to reflect the current Portland date **AND** time before the conference starts:

https://github.com/201-created/emberconf-schedule-2018/blob/0f2bd9e46d1d51e24f374a38ea9ae01921d4cc87/app/controllers/index.js#L15-L17