### PR TITLE
Add GitHub prompt text to end of schedule

### DIFF
--- a/src/ui/routes/index/template.hbs
+++ b/src/ui/routes/index/template.hbs
@@ -6,8 +6,10 @@
   }}
 {{/each}}
 
-<h2 class="github">
+<div class="github">
   <a href="https://github.com/201-created/emberconf-schedule-2018" target="_blank" rel="noopener" aria-label="GitHub">
     {{icon-github}}
+    <strong>Curious what's going on here?</strong>
+    Check out the code on GitHub!
   </a>
-</h2>
+</div>

--- a/src/ui/styles/app.scss
+++ b/src/ui/styles/app.scss
@@ -238,9 +238,23 @@ h2 {
 }
 
 .github {
+  padding: 1rem;
+  padding-left: calc(env(safe-area-inset-left) + 1rem);
+  padding-right: calc(env(safe-area-inset-right) + 1rem);
+  text-align: center;
+
+  a {
+    text-decoration: none;
+    color: $github;
+  }
+
   svg {
     width: 2rem;
     height: 2rem;
-    fill: rgba($github, 0.7);
+    fill: $github;
+  }
+
+  strong {
+    display: block;
   }
 }


### PR DESCRIPTION
This expands the GitHub logo at the end of the schedule list to include a similar prompt to the dismissible popup that appears on initial load. This reinforces the messaging of checking out the repo as well as adding some better spacing so the full schedule can be viewed even before the popup prompt is dismissed.

![End of list](https://user-images.githubusercontent.com/250934/37303485-d36b1b00-25eb-11e8-847b-df9bae49a0c3.png)